### PR TITLE
feat!: label with source IP

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,12 +12,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.23'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
   # The "build" workflow
   build:
     # The type of runner that the job will run on
@@ -27,11 +27,11 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     # Setup Go
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: '1.23.3' # The Go version to download (if necessary) and use.
     
@@ -50,7 +50,7 @@ jobs:
       run: go test -coverprofile=c.out ./...
     
     - name: Publish code coverage
-      uses: paambaati/codeclimate-action@v3.2.0
+      uses: paambaati/codeclimate-action@v9
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_REPORTER_ID }}
       with:
@@ -91,23 +91,23 @@ jobs:
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:alpine AS builder
 LABEL maintainer="James Abley <james.abley@gmail.com>"
 
 RUN apk add --no-cache git ca-certificates && update-ca-certificates

--- a/main_test.go
+++ b/main_test.go
@@ -109,14 +109,33 @@ func TestHappyPath(t *testing.T) {
 
 	rateLimitServer := httptest.NewServer(handler(&mockResponse{
 		headers: map[string][]string{
-			"RateLimit-Limit":     {"100;m21600"},
-			"RateLimit-Remaining": {"76;m21600"},
+			"RateLimit-Limit":         {"100;w=21600"},
+			"RateLimit-Remaining":     {"76;w=21600"},
+			"Docker-RateLimit-Source": {"127.0.0.1"},
 		},
 	}))
 	defer rateLimitServer.Close()
 
 	exporter := NewExporter(authServer.URL, rateLimitServer.URL, nil)
 	expectMetrics(t, exporter, "success.metrics")
+}
+
+func TestNoSourceHeaderIsHandled(t *testing.T) {
+	authServer := httptest.NewServer(handler(&mockResponse{
+		response: authResponseBody(),
+	}))
+	defer authServer.Close()
+
+	rateLimitServer := httptest.NewServer(handler(&mockResponse{
+		headers: map[string][]string{
+			"RateLimit-Limit":     {"100;w=21600"},
+			"RateLimit-Remaining": {"76;w=21600"},
+		},
+	}))
+	defer rateLimitServer.Close()
+
+	exporter := NewExporter(authServer.URL, rateLimitServer.URL, nil)
+	expectMetrics(t, exporter, "success-empty-sourceip.metrics")
 }
 
 func TestHappyPathWithBasicAuth(t *testing.T) {
@@ -127,8 +146,9 @@ func TestHappyPathWithBasicAuth(t *testing.T) {
 
 	rateLimitServer := httptest.NewServer(handler(&mockResponse{
 		headers: map[string][]string{
-			"RateLimit-Limit":     {"100;m21600"},
-			"RateLimit-Remaining": {"76;m21600"},
+			"RateLimit-Limit":         {"100;m21600"},
+			"RateLimit-Remaining":     {"76;m21600"},
+			"Docker-RateLimit-Source": {"127.0.0.1"},
 		},
 	}))
 	defer rateLimitServer.Close()
@@ -150,8 +170,9 @@ func TestAuthTokenIsReusedWhenStillValid(t *testing.T) {
 
 	rateLimitServer := httptest.NewServer(handler(&mockResponse{
 		headers: map[string][]string{
-			"RateLimit-Limit":     {"100;m21600"},
-			"RateLimit-Remaining": {"76;m21600"},
+			"RateLimit-Limit":         {"100;m21600"},
+			"RateLimit-Remaining":     {"76;m21600"},
+			"Docker-RateLimit-Source": {"127.0.0.1"},
 		},
 	}))
 	defer rateLimitServer.Close()
@@ -171,8 +192,9 @@ func TestUnableToAnonymouslyAuth(t *testing.T) {
 
 	rateLimitServer := httptest.NewServer(handler(&mockResponse{
 		headers: map[string][]string{
-			"RateLimit-Limit":     {"100;m21600"},
-			"RateLimit-Remaining": {"76;m21600"},
+			"RateLimit-Limit":         {"100;m21600"},
+			"RateLimit-Remaining":     {"76;m21600"},
+			"Docker-RateLimit-Source": {"127.0.0.1"},
 		},
 	}))
 	defer rateLimitServer.Close()
@@ -189,8 +211,9 @@ func TestUnableToBasicAuth(t *testing.T) {
 
 	rateLimitServer := httptest.NewServer(handler(&mockResponse{
 		headers: map[string][]string{
-			"RateLimit-Limit":     {"100;m21600"},
-			"RateLimit-Remaining": {"76;m21600"},
+			"RateLimit-Limit":         {"100;m21600"},
+			"RateLimit-Remaining":     {"76;m21600"},
+			"Docker-RateLimit-Source": {"127.0.0.1"},
 		},
 	}))
 	defer rateLimitServer.Close()
@@ -261,8 +284,9 @@ func TestBadJsonIsIgnored(t *testing.T) {
 
 	rateLimitServer := httptest.NewServer(handler(&mockResponse{
 		headers: map[string][]string{
-			"RateLimit-Limit":     {"100;m21600"},
-			"RateLimit-Remaining": {"76;m21600"},
+			"RateLimit-Limit":         {"100;m21600"},
+			"RateLimit-Remaining":     {"76;m21600"},
+			"Docker-RateLimit-Source": {"127.0.0.1"},
 		},
 	}))
 	defer rateLimitServer.Close()

--- a/test/failure.metrics
+++ b/test/failure.metrics
@@ -6,7 +6,7 @@ dockerhub_exporter_poll_failures_total 1
 dockerhub_exporter_scrapes_total 1
 # HELP dockerhub_limit_max_requests_total Docker Hub Rate Limit Maximum Requests
 # TYPE dockerhub_limit_max_requests_total gauge
-dockerhub_limit_max_requests_total 0
+dockerhub_limit_max_requests_total{source_ip=""} 0
 # HELP dockerhub_limit_remaining_requests_total Docker Hub Rate Limit Remaining Requests
 # TYPE dockerhub_limit_remaining_requests_total gauge
-dockerhub_limit_remaining_requests_total 0
+dockerhub_limit_remaining_requests_total{source_ip=""} 0

--- a/test/success-empty-sourceip.metrics
+++ b/test/success-empty-sourceip.metrics
@@ -3,10 +3,10 @@
 dockerhub_exporter_poll_failures_total 0
 # HELP dockerhub_exporter_scrapes_total Current total Docker Hub scrapes.
 # TYPE dockerhub_exporter_scrapes_total counter
-dockerhub_exporter_scrapes_total 2
+dockerhub_exporter_scrapes_total 1
 # HELP dockerhub_limit_max_requests_total Docker Hub Rate Limit Maximum Requests
 # TYPE dockerhub_limit_max_requests_total gauge
-dockerhub_limit_max_requests_total{source_ip="127.0.0.1"} 100
+dockerhub_limit_max_requests_total{source_ip=""} 100
 # HELP dockerhub_limit_remaining_requests_total Docker Hub Rate Limit Remaining Requests
 # TYPE dockerhub_limit_remaining_requests_total gauge
-dockerhub_limit_remaining_requests_total{source_ip="127.0.0.1"} 76
+dockerhub_limit_remaining_requests_total{source_ip=""} 76

--- a/test/success.metrics
+++ b/test/success.metrics
@@ -6,7 +6,7 @@ dockerhub_exporter_poll_failures_total 0
 dockerhub_exporter_scrapes_total 1
 # HELP dockerhub_limit_max_requests_total Docker Hub Rate Limit Maximum Requests
 # TYPE dockerhub_limit_max_requests_total gauge
-dockerhub_limit_max_requests_total 100
+dockerhub_limit_max_requests_total{source_ip="127.0.0.1"} 100
 # HELP dockerhub_limit_remaining_requests_total Docker Hub Rate Limit Remaining Requests
 # TYPE dockerhub_limit_remaining_requests_total gauge
-dockerhub_limit_remaining_requests_total 76
+dockerhub_limit_remaining_requests_total{source_ip="127.0.0.1"} 76


### PR DESCRIPTION
For environments which have multiple stable egress IP addresses, it can
be helpful to expose this as part of the metrics so that we can see
which IP address is getting close to the allowed usage limits.
    
BREAKING CHANGE: `dockerhub_limit_remaining_requests_total` and
`dockerhub_limit_max_requests_total` now have a `source_ip` label.